### PR TITLE
Fixed build error in 'BinaryXmlElementReader.js'

### DIFF
--- a/wscript
+++ b/wscript
@@ -96,7 +96,7 @@ def build (bld):
                  "js/encoding/BinaryXMLDecoder.js",
                  "js/encoding/BinaryXMLStructureDecoder.js",
                  "js/encoding/WireFormat.js",
-                 "js/util/BinaryXmlElementReader.js",
+                 "js/util/BinaryXMLElementReader.js",
                  "js/util/name-enumeration.js",
                  "js/WebSocketTransport.js",
                  "js/browserifyTcpTransport.js",


### PR DESCRIPTION
Changed the BinaryXmlElementReader to BinaryXMLElementReader to fix
build error.
