### PR TITLE
declare function-scoped var to avoid global leak

### DIFF
--- a/js/encoding/tlv/tlv-decoder.js
+++ b/js/encoding/tlv/tlv-decoder.js
@@ -56,6 +56,7 @@ TlvDecoder.prototype.readVarNumber = function()
  */
 TlvDecoder.prototype.readExtendedVarNumber = function(firstOctet)
 {
+  var result;
   // This is a private function so we know firstOctet >= 253.
   if (firstOctet == 253) {
     result = ((this.input[this.offset] << 8) +


### PR DESCRIPTION
in TlvDecoder.prototype.readEntendedVarNumber.

By not declaring 'result' and simply assigning it a value, we leak it to the global scope. detected by mocha testing dependent code in the browser.
