### PR TITLE
declare var firstOctet to avoid global leak

### DIFF
--- a/js/encoding/tlv/tlv-decoder.js
+++ b/js/encoding/tlv/tlv-decoder.js
@@ -39,7 +39,7 @@ exports.TlvDecoder = TlvDecoder;
 TlvDecoder.prototype.readVarNumber = function()
 {
   // Assume array values are in the range 0 to 255.
-  firstOctet = this.input[this.offset];
+  var firstOctet = this.input[this.offset];
   this.offset += 1;
   if (firstOctet < 253)
     return firstOctet;


### PR DESCRIPTION
found while testing dependent code, add var declaration inside TlvDecoder.readVarNumber to avoid global leak
