### PR TITLE
in face.reconnectAndExpressInterest : add check for face.readyStatus

### DIFF
--- a/js/face.js
+++ b/js/face.js
@@ -554,7 +554,7 @@ Face.prototype.expressInterestWithClosure = function(interest, closure)
 Face.prototype.reconnectAndExpressInterest = function(pendingInterestId, interest, closure)
 {
   var thisFace = this;
-  if (!this.connectionInfo.equals(this.transport.connectionInfo)) {
+  if (!this.connectionInfo.equals(this.transport.connectionInfo) || this.readyStatus === Face.UNOPEN) {
     this.readyStatus = Face.OPEN_REQUESTED;
     this.onConnectedCallbacks.push
       (function() { thisFace.expressInterestHelper(pendingInterestId, interest, closure); });


### PR DESCRIPTION
I'm not sure if this is the right way to solve the problem I'm having... there's an outside chance that I might even just be messing something up in my dependent code, but I'm getting thrown the "unexpected connection is not opened" error when testing my HTML5 MessageChannel transport class.

As far as I can see, the only time when face.readyStatus is set to Face.OPEN is within this reconnect function, and if the connectionInfo is equal (which it is when I construct a face via the Face(transport, connectionInfo) API), then this codeblock is skipped and the rest of the 'if' checks in the function fail, throwing an error despite the transport working fine. Adding the secondary condition fixes the problem for me, and I don't see it creating any obvious problems, but I'm open to the possibility I'm missing something.
