### PR TITLE
package.json: Rename from ndn-lib to ndn-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ndn-lib",
+  "name": "ndn-js",
   "version": "0.5.0",
   "description": "NDN-JS:  A javascript client library for Named Data Networking --------------------------------------------------------------",
   "main": "index.js",


### PR DESCRIPTION
Reasons why I propose this:
- This repository is already called `ndn-js`, so I'd expect this to show up under the same name on npmjs.org.
- `ndn-lib` is the same name as the mailing list for "Library use and discussion" (not only JS but all implementations).
