### PR TITLE
package.json: Cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ndn-lib",
   "version": "0.5.0",
-  "description": "NDN-JS:  A javascript client library for Named Data Networking --------------------------------------------------------------",
+  "description": "A JavaScript client library for Named Data Networking",
   "main": "index.js",
   "directories": {
     "example": "examples",
@@ -17,9 +17,9 @@
   "keywords": [
     "NDN"
   ],
-  "browser":{
-     "./js/crypto.js": "./js/browserify.js", 
-     "./js/transport/tcp-transport.js": "./js/browserify-tcp-transport.js"
+  "browser": {
+    "./js/crypto.js": "./js/browserify.js",
+    "./js/transport/tcp-transport.js": "./js/browserify-tcp-transport.js"
   },
   "author": "UCLA",
   "license": "LGPL-3.0+",


### PR DESCRIPTION
This also fixes whitespace in such a way that a subsequent execution of `npm version` really only changes the line with the version number.
