### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ npm-debug.log
 
 # Temporary test files
 js/sync/hash-test.js
+
+# Ignore installed dependencies
+node_modules


### PR DESCRIPTION
When installed, ndn-js will install dependencies to node_modules and these should be ignored by the Git repo.