### PR TITLE
browserify: fix crypto library path

### DIFF
--- a/js/browserify.js
+++ b/js/browserify.js
@@ -19,7 +19,7 @@
 
 /** @ignore */
 var ASN1HEX = require('../contrib/securityLib/asn1hex-1.1.js').ASN1HEX /** @ignore */
-var KJUR = require('../contrib/securityLib/crypto-1.0.js').KJUR /** @ignore */
+var KJUR = require('../contrib/securityLib/crypto-1.1.js').KJUR /** @ignore */
 var RSAKey = require('../contrib/securityLib/rsasign-1.2.js').RSAKey /** @ignore */
 var b64tohex = require('../contrib/securityLib/base64.js').b64tohex
 


### PR DESCRIPTION
`browserify.js` incorrects references `crypto-1.0.js` that does not exist, causing build failure when ndn-js is used in [Brunch](https://brunch.io/).