### PR TITLE
browserify: fix require().printStackTrace

### DIFF
--- a/js/browserify-stacktrace.js
+++ b/js/browserify-stacktrace.js
@@ -20,4 +20,4 @@
 // This is included after stacktrace.js and browserify-require.js so that
 // require().printStackTrace works.
 
-exports.printStackTrace = printStackTrace;
+exports.printStackTrace = globals.printStackTrace;


### PR DESCRIPTION
require().printStackTrace is broken since ndn.noConflict() change.
This commit makes it work again.