### PR TITLE
[Bug Fix] Fixed bug of returning undefined in 3 get methods

### DIFF
--- a/js/impl/registered-prefix-table.js
+++ b/js/impl/registered-prefix-table.js
@@ -135,7 +135,7 @@ RegisteredPrefixTable._Entry = function RegisteredPrefixTableEntry
  */
 RegisteredPrefixTable._Entry.prototype.getRegisteredPrefixId = function()
 {
-  return this.registeredPrefixId;
+  return this.registeredPrefixId_;
 };
 
 /**
@@ -144,7 +144,7 @@ RegisteredPrefixTable._Entry.prototype.getRegisteredPrefixId = function()
  */
 RegisteredPrefixTable._Entry.prototype.getPrefix = function()
 {
-  return this.prefix;
+  return this.prefix_;
 };
 
 /**
@@ -153,5 +153,5 @@ RegisteredPrefixTable._Entry.prototype.getPrefix = function()
  */
 RegisteredPrefixTable._Entry.prototype.getRelatedInterestFilterId = function()
 {
-  return this.relatedInterestFilterId;
+  return this.relatedInterestFilterId_;
 };


### PR DESCRIPTION
Fixed bug of returning undefined in 3 get methods of RegisteredPrefixTable._Entry by correcting the variable names.

In the previous code, '_' is missing in the returned variable names in the three get methods of RegisteredPrefixTable._Entry, which will cause them to return undefined values. Furthermore, it will result in failing to remove registered prefix by calling Face.prototype.removeRegisteredPrefix.