### PR TITLE
[Bug Fix] Fix checking [otherTypeCode] against NaN

### DIFF
--- a/js/name.js
+++ b/js/name.js
@@ -673,7 +673,7 @@ Name.createNameArray = function(uri)
       if (iTypeCodeEnd >= 0) {
         var typeString = componentString.substring(0, iTypeCodeEnd);
         otherTypeCode = parseInt(typeString);
-        if (otherTypeCode === NaN)
+        if (isNaN(otherTypeCode))
           throw new Error
             ("Can't parse decimal Name Component type: " + typeString +
              " in URI " + uri);


### PR DESCRIPTION
In the previous code, "otherTypeCode === NaN" always returns false because, in JavaScript, NaN is the only number not equal to itself.
Changing to isNaN() may still not be the best solution. Please refer to [The Problem with Testing for NaN in JavaScript](http://adripofjavascript.com/blog/drips/the-problem-with-testing-for-nan-in-javascript.html) for other choices.