### PR TITLE
security: don't use deprecated 'constant' module

### DIFF
--- a/js/encrypt/algo/rsa-algorithm.js
+++ b/js/encrypt/algo/rsa-algorithm.js
@@ -22,7 +22,7 @@
 // "Rsa" is very short and not all the Common Client Libraries have namespaces.)
 
 /** @ignore */
-var constants = require('constants'); /** @ignore */
+var cryptoConstants = require('crypto').constants; /** @ignore */
 var Crypto = require('../../crypto.js'); /** @ignore */
 var Blob = require('../../util/blob.js').Blob; /** @ignore */
 var DecryptKey = require('../decrypt-key.js').DecryptKey; /** @ignore */
@@ -193,9 +193,9 @@ RsaAlgorithm.decryptPromise = function(keyBits, encryptedData, params, useSync)
 
     var padding;
     if (params.getAlgorithmType() == EncryptAlgorithmType.RsaPkcs)
-      padding = constants.RSA_PKCS1_PADDING;
+      padding = cryptoConstants.RSA_PKCS1_PADDING;
     else if (params.getAlgorithmType() == EncryptAlgorithmType.RsaOaep)
-      padding = constants.RSA_PKCS1_OAEP_PADDING;
+      padding = cryptoConstants.RSA_PKCS1_OAEP_PADDING;
     else
       return SyncPromise.reject(new Error("unsupported padding scheme"));
 

--- a/js/security/certificate/public-key.js
+++ b/js/security/certificate/public-key.js
@@ -20,7 +20,7 @@
 
 // Use capitalized Crypto to not clash with the browser's crypto.subtle.
 /** @ignore */
-var constants = require('constants'); /** @ignore */
+var cryptoConstants = require('crypto').constants; /** @ignore */
 var Crypto = require('../../crypto.js'); /** @ignore */
 var Blob = require('../../util/blob.js').Blob; /** @ignore */
 var DerNode = require('../../encoding/der/der-node.js').DerNode; /** @ignore */
@@ -170,13 +170,13 @@ PublicKey.prototype.encryptPromise = function(plainData, algorithmType, useSync)
       if (this.keyType != KeyType.RSA)
         return SyncPromise.reject(new Error("The key type must be RSA"));
 
-      padding = constants.RSA_PKCS1_PADDING;
+      padding = cryptoConstants.RSA_PKCS1_PADDING;
     }
     else if (algorithmType == EncryptAlgorithmType.RsaOaep) {
       if (this.keyType != KeyType.RSA)
         return SyncPromise.reject(new Error("The key type must be RSA"));
 
-      padding = constants.RSA_PKCS1_OAEP_PADDING;
+      padding = cryptoConstants.RSA_PKCS1_OAEP_PADDING;
     }
     else
       return SyncPromise.reject(new Error("unsupported padding scheme"));

--- a/js/security/tpm/tpm-private-key.js
+++ b/js/security/tpm/tpm-private-key.js
@@ -20,7 +20,7 @@
 
 // Use capitalized Crypto to not clash with the browser's crypto.subtle.
 /** @ignore */
-var constants = require('constants'); /** @ignore */
+var cryptoConstants = require('crypto').constants; /** @ignore */
 var Crypto = require('../../crypto.js'); /** @ignore */
 var KeyType = require('../security-types').KeyType; /** @ignore */
 var EncryptAlgorithmType = require('../../encrypt/algo/encrypt-params.js').EncryptAlgorithmType; /** @ignore */
@@ -296,9 +296,9 @@ TpmPrivateKey.prototype.decryptPromise = function
   else {
     var padding;
     if (algorithmType == EncryptAlgorithmType.RsaPkcs)
-      padding = constants.RSA_PKCS1_PADDING;
+      padding = cryptoConstants.RSA_PKCS1_PADDING;
     else if (algorithmType == EncryptAlgorithmType.RsaOaep)
-      padding = constants.RSA_PKCS1_OAEP_PADDING;
+      padding = cryptoConstants.RSA_PKCS1_OAEP_PADDING;
     else
       return SyncPromise.reject(new TpmPrivateKey.Error(new Error
         ("Unsupported padding scheme")));
@@ -615,7 +615,7 @@ TpmPrivateKey.prototype.getSubtleKeyPromise_ = function()
 };
 
 /**
- * A private method to get the cached crypto.subtle key for decrypting, 
+ * A private method to get the cached crypto.subtle key for decrypting,
  * importing it from this.privateKey_ if needed. This means we only have to do
  * this once per session, giving us a small but not insignificant performance
  * boost. This is separate from getSubtleKeyPromise_ because the import


### PR DESCRIPTION
The 'constants' module has been deprecated in Node.js DEP0008 in
favor of 'constants' property exposed by relevant modules.