### PR TITLE
doc: exclude browserify header/footer in jsdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,6 @@
 ndn-protocol/modules/ndn-js.jsm
 tools/micro-forwarder/extension/ndn.js
 
-# JSDoc output
-/doc
-
 # Mac OSX
 .DS_Store
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: node_js
 sudo: false
 node_js:
   - "8"
-branches:
-  only:
-    - master
 script:
-  - npm install -g jsdoc
-  - jsdoc --recurse --destination doc js README.md
-after_success:
-  - ssh-keyscan -H $HOSTNAME 2>&1 | tee -a $HOME/.ssh/known_hosts
-  - openssl aes-256-cbc -K $encrypted_2891f088a2e3_key -iv $encrypted_2891f088a2e3_iv -in .travis.d/id-rsa.enc -out .travis.d/id-rsa -d
-  - mkdir -p ~/.ssh && mv .travis.d/id-rsa ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
-  - rsync -arv --delete --progress doc/ $USERNAME@$HOSTNAME:/var/www/named-data.net/www/doc/ndn-ccl/latest/NDN-JS
-  # TODO: sync tagged versions
+  - npm run doc
+deploy:
+  provider: script
+  script:
+    - ssh-keyscan -H $HOSTNAME 2>&1 | tee -a $HOME/.ssh/known_hosts
+    - openssl aes-256-cbc -K $encrypted_2891f088a2e3_key -iv $encrypted_2891f088a2e3_iv -in .travis.d/id-rsa.enc -out .travis.d/id-rsa -d
+    - mkdir -p ~/.ssh && mv .travis.d/id-rsa ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
+    - rsync -arv --delete --progress doc/ $USERNAME@$HOSTNAME:/var/www/named-data.net/www/doc/ndn-ccl/latest/NDN-JS
+    # TODO: sync tagged versions
+  on:
+    branch: master

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!conf.json

--- a/doc/conf.json
+++ b/doc/conf.json
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "include": ["js", "README.md"],
+    "exclude": ["js/browserify-header.js", "js/browserify-footer.js"]
+  },
+  "opts": {
+    "destination": "doc",
+    "recurse": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "tests"
   },
   "scripts": {
+    "doc": "jsdoc -c doc/conf.json",
     "test": "cd tests/node/unit-tests ; mocha . --timeout 10000 ; cd ../../.."
   },
   "repository": {
@@ -19,7 +20,7 @@
   ],
   "browser": {
     "./js/crypto.js": "./js/browserify.js",
-    "./js/use-subtle-crypto-node.js":"./js/use-subtle-crypto.js",
+    "./js/use-subtle-crypto-node.js": "./js/use-subtle-crypto.js",
     "./js/transport/tcp-transport.js": "./js/browserify-tcp-transport.js"
   },
   "author": "UCLA",
@@ -32,6 +33,7 @@
     "protobufjs": "*"
   },
   "devDependencies": {
+    "jsdoc": "*",
     "mocha": "*"
   }
 }


### PR DESCRIPTION
browserify-header.js and browserify-footer.js are not complete
JavaScript files, so they should not be processed by jsdoc.

This commit also changes Travis CI script to build documentation
on every branch and pull request, but deploy them only for the
master branch.

fixes #4774