### PR TITLE
security: replace rsa-keygen with rsa-keypair

### DIFF
--- a/js/encrypt/algo/rsa-algorithm.js
+++ b/js/encrypt/algo/rsa-algorithm.js
@@ -34,10 +34,10 @@ var PrivateKeyStorage = require('../../security/identity/private-key-storage.js'
 var UseSubtleCrypto = require('../../use-subtle-crypto-node.js').UseSubtleCrypto; /** @ignore */
 var SyncPromise = require('../../util/sync-promise.js').SyncPromise; /** @ignore */
 var PublicKey = require('../../security/certificate/public-key.js').PublicKey; /** @ignore */
-var rsaKeygen = null;
+var RsaKeypair = null;
 try {
-  // This should be installed with: sudo npm install rsa-keygen
-  rsaKeygen = require('rsa-keygen');
+  // This should be installed with: sudo npm install rsa-keypair
+  RsaKeypair = require('rsa-keypair');
 }
 catch (e) {}
 
@@ -80,14 +80,14 @@ RsaAlgorithm.generateKeyPromise = function(params, useSync)
     });
   }
   else {
-    if (!rsaKeygen)
+    if (!RsaKeypair)
       return SyncPromise.reject(new Error
-        ("Need to install rsa-keygen: sudo npm install rsa-keygen"));
+        ("Need to install rsa-keypair: sudo npm install rsa-keypair"));
 
     try {
-      var keyPair = rsaKeygen.generate(params.getKeySize());
+      var keyPair = RsaKeypair.generate(params.getKeySize());
       // Get the PKCS1 private key DER from the PEM string and encode as PKCS8.
-      var privateKeyBase64 = keyPair.private_key.toString().replace
+      var privateKeyBase64 = keyPair.privateKey.toString().replace
         ("-----BEGIN RSA PRIVATE KEY-----", "").replace
         ("-----END RSA PRIVATE KEY-----", "");
       var pkcs1PrivateKeyDer = new Buffer(privateKeyBase64, 'base64');

--- a/js/security/identity/file-private-key-storage.js
+++ b/js/security/identity/file-private-key-storage.js
@@ -37,10 +37,10 @@ var util = require('util');
 var Crypto = require('../../crypto.js'); /** @ignore */
 var fs = require('fs'); /** @ignore */
 var path = require('path'); /** @ignore */
-var rsaKeygen = null;
+var RsaKeypair = null;
 try {
-  // This should be installed with: sudo npm install rsa-keygen
-  rsaKeygen = require('rsa-keygen');
+  // This should be installed with: sudo npm install rsa-keypair
+  RsaKeypair = require('rsa-keypair');
 }
 catch (e) {}
 
@@ -95,20 +95,20 @@ FilePrivateKeyStorage.prototype.generateKeyPairPromise = function
 
   // build keys
   if (params.getKeyType() === KeyType.RSA) {
-    if (!rsaKeygen)
+    if (!RsaKeypair)
       return SyncPromise.reject(new SecurityException(new Error
-        ("Need to install rsa-keygen: sudo npm install rsa-keygen")));
+        ("Need to install rsa-keypair: sudo npm install rsa-keypair")));
 
-    var keyPair = rsaKeygen.generate(params.getKeySize());
+    var keyPair = RsaKeypair.generate(params.getKeySize());
 
     // Get the public key DER from the PEM string.
-    var publicKeyBase64 = keyPair.public_key.toString().replace
+    var publicKeyBase64 = keyPair.publicKey.toString().replace
       ("-----BEGIN PUBLIC KEY-----", "").replace
       ("-----END PUBLIC KEY-----", "");
     var publicKey = new Buffer(publicKeyBase64, 'base64');
 
     // Get the PKCS1 private key DER from the PEM string and encode as PKCS8.
-    var privateKeyBase64 = keyPair.private_key.toString().replace
+    var privateKeyBase64 = keyPair.privateKey.toString().replace
       ("-----BEGIN RSA PRIVATE KEY-----", "").replace
       ("-----END RSA PRIVATE KEY-----", "");
     var pkcs1PrivateKeyDer = new Buffer(privateKeyBase64, 'base64');

--- a/js/security/identity/memory-private-key-storage.js
+++ b/js/security/identity/memory-private-key-storage.js
@@ -33,10 +33,10 @@ var DerNode = require('../../encoding/der/der-node.js').DerNode; /** @ignore */
 var OID = require('../../encoding/oid.js').OID; /** @ignore */
 var SyncPromise = require('../../util/sync-promise.js').SyncPromise; /** @ignore */
 var UseSubtleCrypto = require('../../use-subtle-crypto-node.js').UseSubtleCrypto; /** @ignore */
-var rsaKeygen = null;
+var RsaKeypair = null;
 try {
-  // This should be installed with: sudo npm install rsa-keygen
-  rsaKeygen = require('rsa-keygen');
+  // This should be installed with: sudo npm install rsa-keypair
+  RsaKeypair = require('rsa-keypair');
 }
 catch (e) {}
 
@@ -213,19 +213,19 @@ MemoryPrivateKeyStorage.prototype.generateKeyPairPromise = function
         var privateKeyPem;
 
         if (params.getKeyType() === KeyType.RSA) {
-          if (!rsaKeygen)
+          if (!RsaKeypair)
             return SyncPromise.reject(new SecurityException(new Error
-              ("Need to install rsa-keygen: sudo npm install rsa-keygen")));
+              ("Need to install rsa-keypair: sudo npm install rsa-keypair")));
 
-          var keyPair = rsaKeygen.generate(params.getKeySize());
+          var keyPair = RsaKeypair.generate(params.getKeySize());
 
           // Get the public key DER from the PEM string.
-          var publicKeyBase64 = keyPair.public_key.toString().replace
+          var publicKeyBase64 = keyPair.publicKey.toString().replace
             ("-----BEGIN PUBLIC KEY-----", "").replace
             ("-----END PUBLIC KEY-----", "");
           publicKeyDer = new Buffer(publicKeyBase64, 'base64');
 
-          privateKeyPem = keyPair.private_key.toString();
+          privateKeyPem = keyPair.privateKey.toString();
         }
         else
           return SyncPromise.reject(new SecurityException(new Error

--- a/js/security/tpm/tpm-private-key.js
+++ b/js/security/tpm/tpm-private-key.js
@@ -32,10 +32,10 @@ var DerInteger = require('../../encoding/der/der-node.js').DerNode.DerInteger; /
 var OID = require('../../encoding/oid.js').OID; /** @ignore */
 var Blob = require('../../util/blob.js').Blob; /** @ignore */
 var UseSubtleCrypto = require('../../use-subtle-crypto-node.js').UseSubtleCrypto; /** @ignore */
-var rsaKeygen = null;
+var RsaKeypair = null;
 try {
-  // This should be installed with: sudo npm install rsa-keygen
-  rsaKeygen = require('rsa-keygen');
+  // This should be installed with: sudo npm install rsa-keypair
+  RsaKeypair = require('rsa-keypair');
 }
 catch (e) {}
 
@@ -462,12 +462,12 @@ TpmPrivateKey.generatePrivateKeyPromise = function(keyParams, useSync)
     var privateKeyPem;
 
     if (keyParams.getKeyType() === KeyType.RSA) {
-      if (!rsaKeygen)
+      if (!RsaKeypair)
         return SyncPromise.reject(new TpmPrivateKey.Error(new Error
-          ("Need to install rsa-keygen: sudo npm install rsa-keygen")));
+          ("Need to install rsa-keypair: sudo npm install rsa-keypair")));
 
-      var keyPair = rsaKeygen.generate(keyParams.getKeySize());
-      privateKeyPem = keyPair.private_key.toString();
+      var keyPair = RsaKeypair.generate(keyParams.getKeySize());
+      privateKeyPem = keyPair.privateKey.toString();
     }
     else
       return SyncPromise.reject(new Error


### PR DESCRIPTION
rsa-keygen package has been unmaintained for years and it no longer compiles with NodeJS 10.x.