### PR TITLE
Package: Update the protobufjs dependency to a compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "jsbn": "*",
-    "protobufjs": "*"
+    "protobufjs": "^5.0.3"
   },
   "devDependencies": {
     "jsdoc": "*",


### PR DESCRIPTION
Hey guys, looks like the newest version of protobufjs isn't compatible with the library so I updated it to the newest one that works.